### PR TITLE
Don't notify if buffer is active

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Requires an API key from http://pushbullet.com and a recentish version of Weecha
 ### Optional settings
 `/set plugins.var.python.weebullet.away_only [0|1]` set to `0` if you wish to always receive notifications, or only when you are marked away (default `1`)
 
+`/set plugins.var.python.weebullet.inactive_only [0|1]` set to `0` to receive notifications for your active buffer, or `1` to skip notifications for the active buffer (default `1`)
+
 `/set plugins.var.python.weebullet.device_iden [DEVICE_ID|all]` if you wish to be notified only on a specific device, or on all devices (default `all`)
 
 `/set plugins.var.python.weebullet.ignored_channels [#channel1[, #channel2[, #channel3[, ...]]]]` if you wish to set ignored channels manually (default blank)

--- a/weebullet.py
+++ b/weebullet.py
@@ -46,6 +46,7 @@ w.hook_command(
 configs = {
     "api_key": REQUIRED,
     "away_only": "1",            # only send when away
+    "inactive_only": "1",        # only send if buffer inactive
     "device_iden": "all",        # send to all devices
     "ignored_channels": "",      # no ignored channels
     "min_notify_interval": "0",  # seconds, don't notify
@@ -252,6 +253,15 @@ def priv_msg_cb(data, bufferp, uber_empty,
         # TODO: make debug a configurable
         debug("Not away, skipping notification")
         return w.WEECHAT_RC_OK
+
+    # If 'inactive_only' is enabled, we need to check if the notification is
+    # coming from the active buffer.
+    if w.config_get_plugin("inactive_only") == "1":
+        if w.current_buffer() == bufferp:
+            # The notification came from the current buffer - don't notify
+            debug("Notification came from the active buffer, "
+                  "skipping notification")
+            return w.WEECHAT_RC_OK
 
     notif_body = u"<%s> %s" % (
         prefix.decode('utf-8'),


### PR DESCRIPTION
This patch adds a new configuration option, `inactive only`, that
allows a user to disable notifications for a buffer that is active.

For example, if a user has a private message buffer active, they
may not want pushbullet messages sent to them from conversations
in that buffer.

Users can set `inactive_only` to `0` if they still want pushbullet
notifications even in their active buffers.