### PR TITLE
rewrite: subscribed channels, complete refactor, pep8 formatting, switch from python2 to python3, and more!

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,33 +5,34 @@ Weechat script to push notifications to Pushbullet.
 Requires an API key from http://pushbullet.com and a recentish version of Weechat with Python support enabled.
 
 ### Setup
+
 - Place `weebullet.py` in `~/.weechat/python`
 - `/script load weebullet.py` (or `/python load weebullet.py` for newer weechats)
 - `/set plugins.var.python.weebullet.api_key YOUR_API_KEY`
 - Enjoy!
 
-### Additional commands
-`/send_push_note`  - sends a push manually from weechat
+### Commands
 
-`/weebullet` - without arguments, prints a help message
+| Command                     | Description |
+|---|---|
+| `/weebullet ignore`         | adds to the list of ignored channels |
+| `/weebullet unignore`       | removes from the list of ignored channels |
+| `/weebullet subscribe`      | adds to the list of subscribed channels |
+| `/weebullet unsubscribe`    | removes from the list of subscribed channels |
+| `/weebullet listignored`    | list ignored channels |
+| `/weebullet listsubscribed` | list subscribed channels |
+| `/weebullet listdevices`    | list devices associated with your pushbullet API key |
+| `/weebullet test`           | send a test notification to the devices in notify_devices |
+| `/weebullet help`           | prints this help message |
 
-`/weebullet listdevices` - retrieves a list of your pushable devices and their nicknames
+### Settings
 
-`/weebullet listignores` - retrieves a list of ignored channels
-
-`/weebullet ignore` - ignores a given channel or channels
-
-`/weebullet unignore` - unignores a given channel or channels
-
-### Optional settings
-`/set plugins.var.python.weebullet.away_only [0|1]` set to `0` if you wish to always receive notifications, or only when you are marked away (default `1`)
-
-`/set plugins.var.python.weebullet.inactive_only [0|1]` set to `0` to receive notifications for your active buffer, or `1` to skip notifications for the active buffer (default `1`)
-
-`/set plugins.var.python.weebullet.device_iden [DEVICE_ID|all]` if you wish to be notified only on a specific device, or on all devices (default `all`)
-
-`/set plugins.var.python.weebullet.ignored_channels [#channel1[, #channel2[, #channel3[, ...]]]]` if you wish to set ignored channels manually (default blank)
-
-`/set plugins.var.python.weebullet.min_notify_interval [0|NUMBER]` to set a minimum interval in seconds between notifications (default 0, disabled)
-
-`/set plugins.var.python.weebullet.ignore_on_relay [0|1]` set to 1 if you want to suppress push notifications when a client is connected to your weechat via weechat-relay (default `0`)
+| Setting             | Description |
+|---|---|
+| `api_key`             | your pushbullet API key **(required)** |
+| `away_only`           | send only when marked as away<br>values: `0` or `1`; default: `1` |
+| `inactive_only`       | send only when the message is in an inactive buffer<br>values: `0` or `1`; default: `0` |
+| `ignore_on_relay`     | ignore notifications when a relay is connected<br>values: `0` or `1`; default: `0` |
+| `notify_devices`      | list of device identifiers to notify<br>value: comma separated device identifiers, default: `all` |
+| `min_notify_interval` | minimum number of seconds to wait before another notification<br>value: integer number of seconds, default: `60` |
+| `api_timeout`         | number of seconds to api request timeout<br>value: integer number of seconds, default: `20` |

--- a/weebullet.py
+++ b/weebullet.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# vim: set fileencoding=utf8 ts=4 sw=4 expandtab :
+#!/usr/bin/env python3
 
 import json
 import re
@@ -8,286 +7,389 @@ import time
 
 import weechat as w
 
-# Constant used to check if configs are required
-REQUIRED = '_required'
 
-w.register('weebullet',
-           'Lefty',
-           '0.5.1',
-           'BSD',
-           'weebullet pushes notifications from IRC to Pushbullet.',
-           '', '')
+description = "weebullet pushes notifications from weechat to pushbullet"
 
-w.hook_print("", "irc_privmsg", "", 1, "priv_msg_cb", "")
-w.hook_command(
-    "send_push_note",      # command
-    "send a push note",    # description
-    "[message]"            # arguments description,
-    "",                    # argument
-    "",
-    "",
-    "cmd_send_push_note", ""
-)
-w.hook_command(
-    "weebullet",
-    "pushes notifications from IRC to Pushbullet",
-    "[command]",
-    "Available commands are:\n"
-    "   help        : prints config options and defaults\n"
-    "   listdevices : prints a list of all devices associated"
-    "                 with your Pushbullet API key\n"
-    "   listignores : prints a list of channels that highlights "
-    "                 won't be pushed for\n"
-    "   ignore      : adds a channel to the blacklist\n"
-    "   unignore    : removes a channel from the blacklist",
-    "",
-    "cmd_help", ""
-)
-configs = {
-    "api_key": REQUIRED,
-    "away_only": "1",            # only send when away
-    "inactive_only": "1",        # only send if buffer inactive
-    "device_iden": "all",        # send to all devices
-    "ignored_channels": "",      # no ignored channels
-    "min_notify_interval": "0",  # seconds, don't notify
-                                 #   more often than this
-    "debug": "0",                # enable debugging
-    "ignore_on_relay": "0",      # if relay connected,
-                                 #   don't send push notification
+help_text = """
+commands:
+    /weebullet ignore           adds to the list of ignored channels
+    /weebullet unignore         removes from the list of ignored channels
+    /weebullet subscribe        adds to the list of subscribed channels
+    /weebullet unsubscribe      removes from the list of subscribed channels
+    /weebullet listignored      list ignored channels
+    /weebullet listsubscribed   list subscribed channels
+    /weebullet listdevices      list devices associated with your pushbullet API key
+    /weebullet test             send a test notification to the devices in notify_devices
+    /weebullet help             prints this help message
+
+examples:
+    /weebullet ignore #foo,#bar,#baz
+    /weebullet subscribe #foo,#bar
+    /weebullet listignored
+    /weebullet listdevices
+
+settings: (prefix with plugins.var.python.weebullet.<setting>)
+    api_key               your pushbullet API key (required)
+    away_only             send only when marked as away
+                          value: [0|1], default: 1
+    inactive_only         send only when the message is in an inactive buffer
+                          value: [0|1], default: 0
+    ignore_on_relay       ignore notifications when a relay is connected
+                          value: [0|1], default: 0
+    notify_devices        list of device identifiers to notify
+                          value: comma separated device identifiers, default: all
+    min_notify_interval   minimum number of seconds to wait before another notification
+                          value: integer number of seconds, default: 60
+    api_timeout           number of seconds to api request timeout
+                          value: integer number of seconds, default: 20
+"""
+
+
+configs = {                      # some sane defaults
+    'api_key': '_required',      
+    'ignored_channels': '',      # no ignored channels
+    'subscribed_channels': '',   # no subscribed channels
+    'away_only': '1',            # send only when away
+    'inactive_only': '0',        # send even if buffer is active
+    'ignore_on_relay': '0',      # send even if relay is connected
+    'notify_devices': 'all',     # send to all devices
+    'min_notify_interval': '60', # send notifications at least a minute apart
+    'api_timeout': '20',         # 20 seconds ought to be enough
+    'debug': '0',                # enable debugging
 }
 
-last_notification = 0   # 0 seconds from the epoch
 
-for option, default_value in configs.items():
-    if w.config_get_plugin(option) == "":
-        if configs[option] == REQUIRED:
-            w.prnt("", w.prefix("error") +
-                   "pushbullet: Please set option: %s" % option)
-            if type(default_value) == "str":
-                w.prnt("", "pushbullet: /set plugins.var.python.weebullet.%s STRING" % option)
-            elif type(default_value) == "int":
-                w.prnt("", "pushbullet: /set plugins.var.python.weebullet.%s INT" % option)
-            else:
-                w.prnt("", "pushbullet: /set plugins.var.python.weebullet.%s VALUE" % option)
-        else:
-            w.config_set_plugin(option, configs[option])
+last_notification = 0
 
 
 def debug(msg):
-    if str(w.config_get_plugin("debug")) is not "0":
-        w.prnt("", "[weebullet] DEBUG: %s" % str(msg))
+    if str(w.config_get_plugin('debug')) != '0':
+        w.prnt('', '[weebullet] debug: {}'.format(str(msg)))
 
 
-def process_devicelist_cb(data, url, status, response, err):
+def register():
+    w.register('weebullet', 'Lefty', '0.6', 'BSD', description, '', '')
+
+
+def load_settings():
+    for (option, default_value) in configs.items():
+        if w.config_get_plugin(option) == '':
+            if configs[option] == '_required':
+                w.prnt('', 'missing plugins.var.python.weebullet.{}'.format(option))
+            else:
+                w.config_set_plugin(option, configs[option])
+
+
+def setup_hooks():
+    global description
+    global help_text
+
+    w.hook_print('', '', '', 1, 'message_hook', '')
+    w.hook_command('weebullet', description, '[command]', help_text, '', 'process_command', '')
+
+
+def process_devicelist_cb(
+    data,
+    url,
+    status,
+    response,
+    err,
+):
     try:
-        devices = json.loads(response)["devices"]
-        w.prnt("", "Device List:")
+        devices = json.loads(response)['devices']
+        w.prnt('', 'devices:')
         for device in devices:
-            if device["pushable"]:
-                if "nickname" in device:
-                    w.prnt("", "---\n%s" % device["nickname"])
+            if device['pushable']:
+                if 'nickname' in device:
+                    device_name = device['nickname']
                 else:
-                    w.prnt("", "---\nUnnamed")
-                w.prnt("", "%s" % device["iden"])
+                    device_name = '<unnamed>'
+                w.prnt('', '    {}: {}'.format(device_name, device['iden']))
     except KeyError:
-        w.prnt("", "[weebullet] Error accessing device list: %s" % response)
+        w.prnt('', '[weebullet] error accessing devices: {}'.format(response))
         return w.WEECHAT_RC_ERROR
+
     return w.WEECHAT_RC_OK
 
 
-def get_ignored_channels():
-    ignored_channels = w.config_get_plugin("ignored_channels")
-    if ignored_channels == "":
-        return []
+def get_api_key():
+    return w.string_eval_expression(w.config_get_plugin('api_key'), {}, {}, {})
+
+
+def get_devices():
+    api_key = get_api_key()
+    apiurl = 'https://{}@api.pushbullet.com/v2/devices'.format(api_key)
+    w.hook_process(
+        'url:' + apiurl,
+        int(w.config_get_plugin('api_timeout'))*1000,
+        'process_devicelist_cb',
+        '',
+    )
+
+    return ""
+
+
+def get_channels(kind):
+    channels = w.config_get_plugin('{}_channels'.format(kind))
+    if channels == '':
+        return set([])
     else:
-        return [channel.strip() for channel in ignored_channels.split(',')]
+        return set([channel.strip() for channel in channels.split(' ')])
 
 
-def cmd_help(data, buffer, args):
-    # Get current list of ignored channels in list form
-    ignored_channels = get_ignored_channels()
+def process_command(data, buffer, args):
+    # process the following commands:
+    #   /weebullet ignore CHANNELS
+    #   /weebullet subscribe CHANNELS
+    for kind in ['ignore', 'subscribe']:
+        channels = get_channels(kind + "d")
 
-    # a map of what to do to what when one of the following commands is executed
-    commands = {
-        'ignore': lambda channel: ignored_channels.append(channel),
-        'unignore': lambda channel: ignored_channels.remove(channel),
+        action_commands = {
+            kind: lambda channel: channels.add(channel),
+            'un{}'.format(kind): lambda channel: channels.remove(channel),
+        }
+
+        for command in action_commands:
+            command_regex = re.match('^' + command + '\s+(.+)', args)
+            if command_regex is not None:
+                new_channels = command_regex.group(1).split(' ')
+                for new_channel in new_channels:
+                    try:
+                        action_commands[command](new_channel)
+                    except Exception as e:
+                        pass
+
+                w.config_set_plugin('{}_channels'.format(kind + "d"), ' '.join(channels))
+
+                return w.WEECHAT_RC_OK
+
+    # process the following commands:
+    #   /weebullet listignored
+    #   /weebullet listsubscribed
+    #   /weebullet listdevices
+    list_commands = {
+        'listignored': lambda: 'Ignored: {}'.format(w.config_get_plugin('ignored_channels')),
+        'listsubscribed': lambda: 'Subscribed: {}'.format(w.config_get_plugin('subscribed_channels')),
+        'listdevices': lambda: get_devices(),
     }
 
-    for command in commands:
-        command_regex = re.match("^" + command + "\s+(.+)", args)
-        if command_regex is not None:
-            action = commands[command]
-
-            new_channels = command_regex.group(1).split(' ')
-            for new_channel in new_channels:
-                commands[command](new_channel)
-
-            w.config_set_plugin('ignored_channels', ', '.join(ignored_channels))
+    for command in list_commands:
+        if args == command:
+            result = list_commands[command]()
+            if result:
+                w.prnt( '', result)
 
             return w.WEECHAT_RC_OK
 
-    if(args == "listignores"):
-        w.prnt("", "Ignored channels: %s" % w.config_get_plugin("ignored_channels"))
-    elif(args == "listdevices"):
-        apikey = w.string_eval_expression(w.config_get_plugin("api_key"), {}, {}, {})
-        apiurl = "https://%s@api.pushbullet.com/v2/devices" % (apikey)
-        w.hook_process("url:" + apiurl, 20000, "process_devicelist_cb", "")
-    else:
-        w.prnt("", """
-Weebullet requires an API key from your Pushbullet account to work. Set your API key with (evaluated):
-    /set plugins.var.python.weebullet.api_key <KEY>
+    # process the following commands:
+    #   /weebullet test
+    if args == 'test':
+        send_push(
+            title='Test push notification',
+            body='Test push notification from weebullet',
+        )
 
-Weebullet will by default only send notifications when you are marked away on IRC. You can change this with:
-    /set plugins.var.python.weebullet.away_only [0|1]
+        return w.WEECHAT_RC_OK
 
-Weebullet will by default send to all devices associated with your Pushbullet account. You can change this with:
-    /set plugins.var.python.weebullet.device_iden <ID>
+    # process the following:
+    #   /weebullet help
+    #   /weebullet <any uncaught command>
+    w.prnt('', help_text)
 
-Weebullet can ignore repeated notifications if they arrive too often.  You can set this with (0 or blank to disable):
-    /set plugins.var.python.weebullet.min_notify_interval <NUMBER>
-
-You can get a list of your devices from the Pushbullet website, or by using
-    /weebullet listdevices
-""")
     return w.WEECHAT_RC_OK
 
 
-def process_pushbullet_cb(data, url, status, response, err):
+def process_pushbullet_cb(
+    data,
+    url,
+    status,
+    response,
+    err,
+):
     body = None
     headers = {}
     lines = response.rstrip().splitlines()
     status_code = int(lines.pop(0).split()[1])
     for line in lines:
-        if body == "":
+        if body == '':
             body += line
             continue
-        header_line = line.split(":", 2)
+        header_line = line.split(':', 2)
         if len(header_line) != 2:
-            body = ""
+            body = ''
             continue
         headers[header_line[0].strip()] = header_line[1].strip()
 
     # response is the string of http body
     if status == w.WEECHAT_HOOK_PROCESS_ERROR:
-        w.prnt("", "[weebullet] Error sending to pushbullet: %s - %s" % (status, url))
+        w.prnt(
+            '',
+            '[weebullet] error sending to pushbullet: {} - {}'.format(
+                status,
+                url,
+            ),
+        )
         return w.WEECHAT_RC_ERROR
 
-    if status_code is 401 or status_code is 403:
-        w.prnt("", "[weebullet] Invalid API Token: %s" % (w.string_eval_expression(w.config_get_plugin("api_key"), {}, {}, {})))
+    if status_code == 401 or status_code == 403:
+        w.prnt(
+            '',
+            '[weebullet] invalid API key: {}'.format(get_api_key()),
+        )
         return w.WEECHAT_RC_ERROR
-    if status_code is not 200:
-        w.prnt("", "[weebullet] Error sending to pushbullet: %s - %s - %s" % (url, status_code, body))
+
+    if status_code != 200:
+        w.prnt(
+            '',
+            '[weebullet] Error sending to pushbullet: {} - {} - {}'.format(
+                url,
+                status_code,
+                body,
+            ),
+        )
         return w.WEECHAT_RC_ERROR
+
+    return w.WEECHAT_RC_OK
+
+
+def away_only_check(bufferp):
+    if w.config_get_plugin('away_only') != '1':
+        return False
+
+    return not w.buffer_get_string(bufferp, 'localvar_away')
+
+
+def inactive_only_check(bufferp):
+    if w.config_get_plugin('inactive_only') != '1':
+        return False
+
+    return w.current_buffer() == bufferp
+
+
+def interval_limit_check():
+    interval = w.config_get_plugin('min_notify_interval')
+
+    if interval is None or interval == '':
+        return False
+
+    try:
+        interval = int(interval)
+    except ValueError:
+        w.prnt('', '[weebullet] min_notify_interval not an integer')
+        return False
+
+    global last_notification
+
+    earliest_allowed = last_notification + interval
+    last_notification = time.time()
+
+    return time.time() < earliest_allowed
+
+
+def relay_check():
+    check_relays = w.config_string_to_boolean(w.config_get_plugin('ignore_on_relay'))
+
+    if not check_relays:
+        return False
+
+    infolist = w.infolist_get('relay', '', '')
+    if infolist:
+        while w.infolist_next(infolist):
+            status = w.infolist_string(infolist, 'status_string')
+            if status == 'connected':
+                return True
+        w.infolist_free(infolist)
+
+    return False
+
+
+def get_buf_name(bufferp):
+    short_name = w.buffer_get_string(bufferp, 'short_name')
+    name = w.buffer_get_string(bufferp, 'name')
+    return (short_name or name).decode('utf-8')
+
+
+def is_ignored(bufferp):
+    buf_name = get_buf_name(bufferp)
+    return buf_name in get_channels('ignored')
+
+
+def is_subscribed(bufferp):
+    buf_name = get_buf_name(bufferp)
+    return buf_name in get_channels('subscribed')
+
+
+def message_hook(
+    data,
+    bufferp,
+    uber_empty,
+    tagsn,
+    is_displayed,
+    is_highlighted,
+    prefix,
+    message,
+):
+    is_pm = w.buffer_get_string(bufferp, 'localvar_type') == 'private'
+    regular_channel = not is_subscribed(bufferp) and not is_pm
+
+    skip = False
+    skip = skip or away_only_check(bufferp)
+    skip = skip or inactive_only_check(bufferp)
+    skip = skip or interval_limit_check()
+    skip = skip or relay_check()
+    skip = skip or (is_ignored(bufferp) and regular_channel)
+    skip = skip or (not is_displayed)
+    skip = skip or (not is_highlighted and regular_channel)
+
+    if skip:
+        return w.WEECHAT_RC_OK
+
+    if is_pm:
+        title = 'PM from {}'.format(prefix.decode('utf-8'))
+    else:
+        title = 'Message on {} from {}'.format(get_buf_name(bufferp), prefix.decode('utf-8'))
+
+    send_push(title=title, body=message.decode('utf-8'))
 
     return w.WEECHAT_RC_OK
 
 
 def send_push(title, body):
-    global last_notification
-
-    interval = w.config_get_plugin("min_notify_interval")
-    if interval is not None and interval != "" and int(interval) != 0:
-        interval = int(interval)
-
-        earliest_notification = last_notification + int(interval)
-
-        if last_notification is not None and time.time() <= earliest_notification:
-            debug("Too soon since last notification, skipping")
-            return w.WEECHAT_RC_OK
-
-    last_notification = time.time()
-
-    # check to see if the relay is connected, ignore if so
-    check_relays = w.config_string_to_boolean(w.config_get_plugin('ignore_on_relay'))
-    CONNECTED_RELAY = False
-    if check_relays:
-        infolist = w.infolist_get('relay', '', '')
-        if infolist:
-            while w.infolist_next(infolist):
-                status = w.infolist_string(infolist, 'status_string')
-                if status == 'connected':
-                    CONNECTED_RELAY = True
-                    break
-            w.infolist_free(infolist)
-
-    if CONNECTED_RELAY is True:
-        # we have a relay conected, don't notify
-        debug("Relay is connected, not sending push.")
-        return w.WEECHAT_RC_OK
-
-    debug("Sending push.  Title: [%s], body: [%s]" % (title, body))
-
-    apikey = w.string_eval_expression(w.config_get_plugin("api_key"), {}, {}, {})
-    apiurl = "https://%s@api.pushbullet.com/v2/pushes" % (apikey)
-    timeout = 20000  # FIXME - actually use config
-    if len(title) is not 0 or len(body) is not 0:
-        deviceiden = w.config_get_plugin("device_iden")
-        if deviceiden == "all":
-            payload = urllib.urlencode({'type': 'note', 'title': title, 'body': body.encode('utf-8')})
+    api_key = get_api_key()
+    apiurl = 'https://{}@api.pushbullet.com/v2/pushes'.format(api_key)
+    timeout = int(w.config_get_plugin('api_timeout')) * 1000
+    if len(title) != 0 or len(body) != 0:
+        deviceiden = w.config_get_plugin('devices')
+        if deviceiden == 'all':
+            payload = urllib.urlencode({
+                'type': 'note',
+                'title': title,
+                'body': body.encode('utf-8')
+            })
         else:
-            payload = urllib.urlencode({'type': 'note', 'title': title, 'body': body.encode('utf-8'), 'device_iden': deviceiden})
-        w.hook_process_hashtable("url:" + apiurl, {"postfields": payload, "header": "1"}, timeout, "process_pushbullet_cb", "")
+            payload = urllib.urlencode({
+                'type': 'note',
+                'title': title,
+                'body': body.encode('utf-8'),
+                'devices': deviceiden,
+            })
 
-
-def cmd_send_push_note(data, buffer, args):
-    send_push(
-        title="Manual Notification from weechat",
-        body=args.decode('utf-8'))
-    return w.WEECHAT_RC_OK
-
-
-def priv_msg_cb(data, bufferp, uber_empty,
-                tagsn, isdisplayed,
-                ishilight, prefix, message):
-    """Sends highlighted message to be printed on notification"""
-
-    if w.config_get_plugin("away_only") == "1":
-        am_away = w.buffer_get_string(bufferp, 'localvar_away')
-    else:
-        am_away = True
-
-    if not am_away:
-        # TODO: make debug a configurable
-        debug("Not away, skipping notification")
-        return w.WEECHAT_RC_OK
-
-    # If 'inactive_only' is enabled, we need to check if the notification is
-    # coming from the active buffer.
-    if w.config_get_plugin("inactive_only") == "1":
-        if w.current_buffer() == bufferp:
-            # The notification came from the current buffer - don't notify
-            debug("Notification came from the active buffer, "
-                  "skipping notification")
-            return w.WEECHAT_RC_OK
-
-    notif_body = u"<%s> %s" % (
-        prefix.decode('utf-8'),
-        message.decode('utf-8')
-    )
-
-    # Check that it's in a "/q" buffer and that I'm not the one writing the msg
-    is_pm = w.buffer_get_string(bufferp, "localvar_type") == "private"
-    is_notify_private = re.search(r'(^|,)notify_private(,|$)', tagsn) is not None
-    # PM (query)
-    if (is_pm and is_notify_private):
-        send_push(
-            title="Privmsg from %s" % prefix.decode('utf-8'),
-            body=notif_body
+        w.hook_process_hashtable(
+            'url:' + apiurl,
+            {
+                'postfields': payload,
+                'header': '1',
+            },
+            timeout,
+            'process_pushbullet_cb',
+            '',
         )
 
-    # Highlight (your nick is quoted)
-    elif (str(ishilight) == "1"):
-        bufname = (w.buffer_get_string(bufferp, "short_name") or
-                   w.buffer_get_string(bufferp, "name"))
 
-        ignored_channels = get_ignored_channels()
+def main():
+    register()
+    load_settings()
+    setup_hooks()
 
-        if bufname not in ignored_channels:
-            send_push(
-                title="Highlight in %s" % bufname.decode('utf-8'),
-                body=notif_body
-            )
-        else:
-            debug("[weebullet] Ignored channel, skipping notification in %s" % bufname.decode('utf-8'))
 
-    return w.WEECHAT_RC_OK
+main()

--- a/weebullet.py
+++ b/weebullet.py
@@ -2,7 +2,7 @@
 
 import json
 import re
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import time
 
 import weechat as w
@@ -72,7 +72,7 @@ def register():
 
 
 def load_settings():
-    for (option, default_value) in configs.items():
+    for (option, default_value) in list(configs.items()):
         if w.config_get_plugin(option) == '':
             if configs[option] == '_required':
                 w.prnt('', 'missing plugins.var.python.weebullet.{}'.format(option))
@@ -361,13 +361,13 @@ def send_push(title, body):
     if len(title) != 0 or len(body) != 0:
         deviceiden = w.config_get_plugin('devices')
         if deviceiden == 'all':
-            payload = urllib.urlencode({
+            payload = urllib.parse.urlencode({
                 'type': 'note',
                 'title': title,
                 'body': body.encode('utf-8')
             })
         else:
-            payload = urllib.urlencode({
+            payload = urllib.parse.urlencode({
                 'type': 'note',
                 'title': title,
                 'body': body.encode('utf-8'),

--- a/weebullet.py
+++ b/weebullet.py
@@ -107,29 +107,26 @@ def cmd_help(data, buffer, args):
     # Get current list of ignored channels in list form
     ignored_channels = get_ignored_channels()
 
-    # Used for checking for ignore/unignore commands and getting the arguments
-    ignore_command = re.match("^ignore\s+(.+)", args)
-    unignore_command = re.match("^unignore\s+(.+)", args)
+    # a map of what to do to what when one of the following commands is executed
+    commands = {
+        'ignore': lambda channel: ignored_channels.append(channel),
+        'unignore': lambda channel: ignored_channels.remove(channel),
+    }
 
-    if(ignore_command is not None):
-        channels_to_ignore = ignore_command.group(1).split(' ')
+    for command in commands:
+        command_regex = re.match("^" + command + "\s+(.+)", args)
+        if command_regex is not None:
+            action = commands[command]
 
-        for channel in channels_to_ignore:
-            if channel not in ignored_channels:
-                ignored_channels.append(channel)
+            new_channels = command_regex.group(1).split(' ')
+            for new_channel in new_channels:
+                commands[command](new_channel)
 
-        w.config_set_plugin("ignored_channels", ','.join(ignored_channels))
-        w.prnt("", "Updated. Ignored channels: %s" % w.config_get_plugin("ignored_channels"))
-    elif(unignore_command is not None):
-        channels_to_unignore = unignore_command.group(1).split(' ')
+            w.config_set_plugin('ignored_channels', ', '.join(ignored_channels))
 
-        for channel in channels_to_unignore:
-            if channel in ignored_channels:
-                ignored_channels.remove(channel)
+            return w.WEECHAT_RC_OK
 
-        w.config_set_plugin("ignored_channels", ','.join(ignored_channels))
-        w.prnt("", "Updated. Ignored channels: %s" % w.config_get_plugin("ignored_channels"))
-    elif(args == "listignores"):
+    if(args == "listignores"):
         w.prnt("", "Ignored channels: %s" % w.config_get_plugin("ignored_channels"))
     elif(args == "listdevices"):
         apikey = w.string_eval_expression(w.config_get_plugin("api_key"), {}, {}, {})


### PR DESCRIPTION
Hey @LeftyBC. Great plugin! I spent a couple of hours refactoring the whole code when I wanted to add a new feature (subscribing to channels: lets you get notifications for **all** messages in a channel irrespective of whether or not you're highlighted).

I'll try to summarise the list of changes:
 - Ported the code to python3 (see https://weechat.org/scripts/python3/)
 - Refactored a lot of code and reduced redundant code
 - Formatted the whole thing to follow PEP8 to an extent (not restricting myself to 80 chars though)
 - Added `subscribe` and `unsubscribe` commands
 - Bumped up the version to 0.6

There is a bit of an API change (rephrased some things); see the README for more information. But since weebullet is still in 0.x (beta software), I think it's okay to change the API without too many consequences.

I know that these are huge changes, so I'll completely understand if you do not want to merge these changes in; I will be maintaining my own fork of that's the case. I'm also submitting the new script to https://weechat.org/scripts.